### PR TITLE
Update README.md: ngram.NewNGramIndex() returns both index and error

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ N-gram index for Go.
 ## Usage
 
 ```go
-index := ngram.NewNGramIndex(ngram.SetN(3))
+index, err := ngram.NewNGramIndex(ngram.SetN(3))
 tokenId, err := index.Add("hello") 
 str, err := index.GetString(tokenId)  // str == "hello"
 resultsList, err := index.Search("world")


### PR DESCRIPTION
The example in the README uses an old function signature of NewNGramIndex; this will add the error return value :) 
